### PR TITLE
add gitattributes file to resolve line end issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
Windows and Linux use different default line endings which may cause Git to report a large number of modified files that have no differences aside from their line endings. 

To prevent this from happening the .gitattributes file can disables line-ending conversion.